### PR TITLE
fix: 修复与 Drill_CoreOfWindowAuxiliary 插件的兼容问题

### DIFF
--- a/Lagomoro_Mission.js
+++ b/Lagomoro_Mission.js
@@ -1532,6 +1532,12 @@ Lagomoro_Mission_Window_Content.prototype.clearItem = function() {
     this._page = [0,0];
 	this.refresh();
 };
+Lagomoro_Mission_Window_Content.prototype.processNewLine = function(textState) {
+    textState.x = textState.left;
+    textState.y += textState.height;
+    textState.height = this.calcTextHeight(textState, false);
+    textState.index++;
+};
 Lagomoro_Mission_Window_Content.prototype.processNormalCharacter = function(textState) {
     var c = textState.text[textState.index];
     var w = this.textWidth(c);


### PR DESCRIPTION
# 修复与 Drill_CoreOfWindowAuxiliary 插件的兼容问题

## 问题描述

与另一个插件 Drill_CoreOfWindowAuxiliary （插件版本：v2.1 Drill_up整合包版本：v3.62） 一同使用时，出现栈溢出报错。
```
RangeError: Maximum call stack size exceeded
    at RegExp.exec (<anonymous>)
    at Lagomoro_Mission_Window_Content.Window_Base.calcTextHeight (rpg_windows.js:408)
    at Lagomoro_Mission_Window_Content.Window_Base.processNewLine (rpg_windows.js:334)
    at Lagomoro_Mission_Window_Content.Window_Base.processNewLine (Drill_CoreOfWindowCharacter.js:1479)
    at Lagomoro_Mission_Window_Content.Window_Base.processNewLine (Drill_CoreOfWindowAuxiliary.js:561)
    at Lagomoro_Mission_Window_Content.processNormalCharacter (Lagomoro_Mission.js:1371)
    at Lagomoro_Mission_Window_Content.processNormalCharacter (Lagomoro_Mission.js:1373)
    at Lagomoro_Mission_Window_Content.processNormalCharacter (Lagomoro_Mission.js:1373)
    at Lagomoro_Mission_Window_Content.processNormalCharacter (Lagomoro_Mission.js:1373)
    at Lagomoro_Mission_Window_Content.processNormalCharacter (Lagomoro_Mission.js:1373)
```

经过排查，我发现 `Drill_CoreOfWindowAuxiliary` 重写了 `Window_Base.prototype.processNewLine`，增加了某些情况下不改变宽度的逻辑。`Lagomoro_Mission_Window_Content` 继承了 `Window_Base` ，调用 `processNewLine` 时产生死循环，导致报错。

## 修复方法

在 Lagomoro_Mission_Window_Content 中重写 processNewLine 方法，恢复原本的换行逻辑，同时不影响其他插件。